### PR TITLE
Update Constants.kt

### DIFF
--- a/src/main/kotlin/it/achdjian/plugin/esp32/Constants.kt
+++ b/src/main/kotlin/it/achdjian/plugin/esp32/Constants.kt
@@ -20,7 +20,8 @@ val AVAILABLE_BAUD_RATE = listOf(
     576000,
     921600,
     1000000,
-    2000000
+    2000000,
+    3000000
 )
 
 const val CONFIGURATION_NAME = "ESP32 flash rom"


### PR DESCRIPTION
The new ESP32-S2 supports baud rates up to 3M.